### PR TITLE
Matrixify Q matrix before comparison with a matrix

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,7 +159,7 @@ end
         @testset "QR" begin
             @nice A = [4 2;0 3//5;0 -4//5;0 0]
             Q, R = qr(A)
-            @test Q == @nice [-1 0 0 0;0 -3/5 4/5 0;0 4/5 3/5 0;0 0 0 1]
+            @test Q * I == @nice [-1 0 0 0;0 -3/5 4/5 0;0 4/5 3/5 0;0 0 0 1]
             @test R == @nice [-4 -2;0 -1]
         end
     end


### PR DESCRIPTION
This came up in a nanosoldier run in https://github.com/JuliaLang/julia/pull/46196. Independently from that PR, it is advisable to matrixify the Q matrix before comparing it via `getindex`, which is slow for Q's. With the proposed change, the tests in this package become independent from whether https://github.com/JuliaLang/julia/pull/46196 gets accepted or not.